### PR TITLE
chore: Add path-browserify and configure webpack resolve fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@eko-ai/eko": "^1.0.9",
     "antd": "^5.22.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@eko-ai/eko": "^1.0.9"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/chrome": "0.0.158",
@@ -26,6 +26,7 @@
     "@types/react-dom": "^18.0.11",
     "copy-webpack-plugin": "^9.0.1",
     "glob": "^7.1.6",
+    "path-browserify": "^1.0.1",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2 ",
     "ts-loader": "^8.0.0",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -33,6 +33,10 @@ module.exports = {
     },
     resolve: {
         extensions: [".ts", ".tsx", ".js"],
+        fallback: {
+            "path": require.resolve("path-browserify"),
+            "fs": false
+        }
     },
     plugins: [
         new CopyWebpackPlugin({


### PR DESCRIPTION
Hi I've posted the issue on another repo: [eko](https://github.com/FellouAI/eko/issues/62), here is my solution to make it work, thanks

This commit adds path-browserify as a dependency and configures webpack to use it as a fallback for the path module in browser environments. The changes include:

- Adding path-browserify to package.json dependencies
- Updating webpack configuration to resolve path module using path-browserify
- Disabling native fs module for browser compatibility
